### PR TITLE
Add IPA notations and the original Greek pronunciations

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,12 +7,12 @@ Some of the pronunciations that we've heard so far.
 
 ## Kubernetes
 
-- _cube-ehr-ne-tees_ &nbsp;/kjʊbɜːnəti:s/
-- _koo-ber-na-tees_ &nbsp;/ku:bɜːnæti:s/
-- _koo-ber-nate_ &nbsp;/ku:bɜːneɪt/
-- _koo-ber-nay-tays_ &nbsp;/ku:bɜːneɪteɪs/
-- _koo-ber-ne-tees_ &nbsp;/ku:bɜːnəti:s/
-- _koo-ber-ne-tehs_ &nbsp;/ku:bɜːnətɛs/
+- _cube-ehr-ne-tees_ &nbsp;/kjʊbɜ:nəti:s/
+- _koo-ber-na-tees_ &nbsp;/ku:bɜ:næti:s/
+- _koo-ber-nate_ &nbsp;/ku:bɜ:neɪt/
+- _koo-ber-nay-tays_ &nbsp;/ku:bɜ:neɪteɪs/
+- _koo-ber-ne-tees_ &nbsp;/ku:bɜ:nəti:s/
+- _koo-ber-ne-tehs_ &nbsp;/ku:bɜ:nətɛs/
 - _kee-ver-nee-tees_ &nbsp;/kivɛrnitis/ (the original Greek pronounciation of the word κυβερνήτης)
 
 ## K8s

--- a/README.md
+++ b/README.md
@@ -7,14 +7,15 @@ Some of the pronunciations that we've heard so far.
 
 ## Kubernetes
 
-- _cube-ehr-ne-tees_
-- _koo-ber-na-tees_
-- _koo-ber-nate_
-- _koo-ber-nay-tays_
-- _koo-ber-ne-tees_
-- _koo-ber-ne-tehs_
+- _cube-ehr-ne-tees_ &nbsp;/kjʊbɜːnəti:s/
+- _koo-ber-na-tees_ &nbsp;/ku:bɜːnæti:s/
+- _koo-ber-nate_ &nbsp;/ku:bɜːneɪt/
+- _koo-ber-nay-tays_ &nbsp;/ku:bɜːneɪteɪs/
+- _koo-ber-ne-tees_ &nbsp;/ku:bɜːnəti:s/
+- _koo-ber-ne-tehs_ &nbsp;/ku:bɜːnətɛs/
+- _kee-ver-nee-tees_ &nbsp;/kivɛrnitis/ (the original Greek pronounciation of the word κυβερνήτης)
 
 ## K8s
 
-- _kay-eights_
-- _kayghties_ (_keighties_)
+- _kay-eights_ &nbsp;/keɪ eɪts/
+- _kayghties_ (_keighties_) &nbsp;/keɪti:s/


### PR DESCRIPTION
Add [IPA](https://en.wikipedia.org/wiki/International_Phonetic_Alphabet) notations and include the original Greek pronunciation.  